### PR TITLE
bugfix for autocomplete lightbox

### DIFF
--- a/atom/keymap.cson
+++ b/atom/keymap.cson
@@ -220,7 +220,7 @@
 
 # autocomplete-plus
 # =================
-'atom-text-editor.autocomplete-active':
+'body atom-text-editor.autocomplete-active':
     'ctrl-j': 'autocomplete-plus:move-down'
     'ctrl-k': 'autocomplete-plus:move-up'
     'ctrl-g': 'autocomplete-plus:cancel'


### PR DESCRIPTION
bugfix for autocomplete lightbox so that vim keymappings work in atom